### PR TITLE
feat: Enhance Redis support with cluster configuration and TLS options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -495,15 +495,22 @@ HELP_AND_FAQ_URL=https://librechat.ai
 # Google tag manager id
 #ANALYTICS_GTM_ID=user provided google tag manager id
 
+#===============#
+# REDIS Options #
+#===============#
+
+# REDIS_URI=10.10.10.10:6379
+# USE_REDIS=true
+
+# USE_REDIS_CLUSTER=true
+# REDIS_CA=/path/to/ca.crt
+
 #==================================================#
 #                      Others                      #
 #==================================================#
 #   You should leave the following commented out   #
 
 # NODE_ENV=
-
-# REDIS_URI=
-# USE_REDIS=
 
 # E2E_USER_EMAIL=
 # E2E_USER_PASSWORD=

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -1,18 +1,15 @@
 const KeyvRedis = require('@keyv/redis');
 const { isEnabled } = require('~/server/utils');
-<<<<<<< HEAD
 const logger = require('~/config/winston');
-=======
 const fs = require('fs');
 const ioredis = require('ioredis');
->>>>>>> 82717228 (feat: Enhance Redis support with cluster configuration and TLS options)
 
 const { REDIS_URI, USE_REDIS, USE_REDIS_CLUSTER, REDIS_CA } = process.env;
 
 let keyvRedis;
 
 function mapURI(uri) {
-  const regex = /^(?<scheme>[a-zA-Z]+):\/\/(?<user>[^:]*):?(?<password>[^@]*)?@?(?<host>[^:\/]+):?(?<port>\d+)?/;
+  const regex = /^(?:(?<scheme>\w+):\/\/)?(?:(?<user>[^:@]+)(?::(?<password>[^@]+))?@)?(?<host>[\w.-]+)(?::(?<port>\d{1,5}))?$/;
   const match = uri.match(regex);
 
   if (match) {

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -7,7 +7,7 @@ const ioredis = require('ioredis');
 const { REDIS_URI, USE_REDIS, USE_REDIS_CLUSTER, REDIS_CA, REDIS_KEY_PREFIX, REDIS_MAX_LISTENERS } = process.env;
 
 let keyvRedis;
-const redis_prefix = REDIS_KEY_PREFIX || "";
+const redis_prefix = REDIS_KEY_PREFIX || '';
 const redis_max_listeners = REDIS_MAX_LISTENERS || 10;
 
 function mapURI(uri) {

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -9,39 +9,40 @@ const { REDIS_URI, USE_REDIS, USE_REDIS_CLUSTER, REDIS_CA } = process.env;
 let keyvRedis;
 
 function mapURI(uri) {
-  const regex = /^(?:(?<scheme>\w+):\/\/)?(?:(?<user>[^:@]+)(?::(?<password>[^@]+))?@)?(?<host>[\w.-]+)(?::(?<port>\d{1,5}))?$/;
+  const regex =
+    /^(?:(?<scheme>\w+):\/\/)?(?:(?<user>[^:@]+)(?::(?<password>[^@]+))?@)?(?<host>[\w.-]+)(?::(?<port>\d{1,5}))?$/;
   const match = uri.match(regex);
 
   if (match) {
-      const { scheme, user, password, host, port } = match.groups;
+    const { scheme, user, password, host, port } = match.groups;
 
-      return {
-          scheme: scheme || 'none',
-          user: user || null,
-          password: password || null,
-          host: host || null,
-          port: port || null,
-      };
+    return {
+      scheme: scheme || 'none',
+      user: user || null,
+      password: password || null,
+      host: host || null,
+      port: port || null,
+    };
   } else {
-      // Handle cases without a scheme
-      const parts = uri.split(':');
-      if (parts.length === 2) {
-          return {
-              scheme: 'none',
-              user: null,
-              password: null,
-              host: parts[0],
-              port: parts[1],
-          };
-      }
-
+    // Handle cases without a scheme
+    const parts = uri.split(':');
+    if (parts.length === 2) {
       return {
-          scheme: 'none',
-          user: null,
-          password: null,
-          host: uri,
-          port: null,
+        scheme: 'none',
+        user: null,
+        password: null,
+        host: parts[0],
+        port: parts[1],
       };
+    }
+
+    return {
+      scheme: 'none',
+      user: null,
+      password: null,
+      host: uri,
+      port: null,
+    };
   }
 }
 

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -14,7 +14,6 @@ let keyvRedis;
 if (REDIS_URI && isEnabled(USE_REDIS)) {
   let redisOptions = null;
   let keyvOpts = { useRedisSets: false };
-  let keyvRedis;
   if (REDIS_CA) {
     const ca = fs.readFileSync(REDIS_CA);
     redisOptions = { tls: { ca } };

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -11,6 +11,43 @@ const { REDIS_URI, USE_REDIS, USE_REDIS_CLUSTER, REDIS_CA } = process.env;
 
 let keyvRedis;
 
+function mapURI(uri) {
+  const regex = /^(?<scheme>[a-zA-Z]+):\/\/(?<user>[^:]*):?(?<password>[^@]*)?@?(?<host>[^:\/]+):?(?<port>\d+)?/;
+  const match = uri.match(regex);
+
+  if (match) {
+      const { scheme, user, password, host, port } = match.groups;
+
+      return {
+          scheme: scheme || 'none',
+          user: user || null,
+          password: password || null,
+          host: host || null,
+          port: port || null,
+      };
+  } else {
+      // Handle cases without a scheme
+      const parts = uri.split(':');
+      if (parts.length === 2) {
+          return {
+              scheme: 'none',
+              user: null,
+              password: null,
+              host: parts[0],
+              port: parts[1],
+          };
+      }
+
+      return {
+          scheme: 'none',
+          user: null,
+          password: null,
+          host: uri,
+          port: null,
+      };
+  }
+}
+
 if (REDIS_URI && isEnabled(USE_REDIS)) {
   let redisOptions = null;
   let keyvOpts = { useRedisSets: false };
@@ -19,18 +56,21 @@ if (REDIS_URI && isEnabled(USE_REDIS)) {
     redisOptions = { tls: { ca } };
   }
   if (isEnabled(USE_REDIS_CLUSTER)) {
-    const hosts = REDIS_URI.split(',')
-      .map((host) => {
-        // TODO parse `host` input to handle connection strings
-        return { host: host };
-      });
+    const hosts = REDIS_URI.split(',').map((item) => {
+      var value = mapURI(item);
+
+      return {
+        host: value.host,
+        port: value.port
+      };
+    });
     const cluster = new ioredis.Cluster(hosts, { redisOptions });
     keyvRedis = new KeyvRedis(cluster, keyvOpts);
   } else {
     keyvRedis = new KeyvRedis(REDIS_URI, keyvOpts);
   }
   keyvRedis.on('error', (err) => logger.error('KeyvRedis connection error:', err));
-  keyvRedis.setMaxListeners(20);
+  keyvRedis.setMaxListeners(0);
   logger.info(
     '[Optional] Redis initialized. Note: Redis support is experimental. If you have issues, disable it. Cache needs to be flushed for values to refresh.',
   );

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -1,13 +1,31 @@
 const KeyvRedis = require('@keyv/redis');
 const { isEnabled } = require('~/server/utils');
+<<<<<<< HEAD
 const logger = require('~/config/winston');
+=======
+const fs = require('fs');
+const ioredis = require('ioredis');
+>>>>>>> 82717228 (feat: Enhance Redis support with cluster configuration and TLS options)
 
-const { REDIS_URI, USE_REDIS } = process.env;
+const { REDIS_URI, USE_REDIS, USE_REDIS_CLUSTER, REDIS_CA } = process.env;
 
 let keyvRedis;
 
 if (REDIS_URI && isEnabled(USE_REDIS)) {
-  keyvRedis = new KeyvRedis(REDIS_URI, { useRedisSets: false });
+  let redisOptions = null;
+  let keyvOpts = { useRedisSets: false };
+  let keyvRedis;
+  if (REDIS_CA) {
+    const ca = fs.readFileSync(REDIS_CA);
+    redisOptions = { tls: { ca } };
+  }
+  if (USE_REDIS_CLUSTER) {
+    const hosts = REDIS_URI.split(',').map((host) => {return { url: host }});
+    const cluster = new ioredis.Cluster(hosts, { redisOptions });
+    keyvRedis = new KeyvRedis(cluster, keyvOpts);
+  } else {
+    keyvRedis = new KeyvRedis(REDIS_URI, keyvOpts);
+  }
   keyvRedis.on('error', (err) => logger.error('KeyvRedis connection error:', err));
   keyvRedis.setMaxListeners(20);
   logger.info(

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -18,8 +18,12 @@ if (REDIS_URI && isEnabled(USE_REDIS)) {
     const ca = fs.readFileSync(REDIS_CA);
     redisOptions = { tls: { ca } };
   }
-  if (USE_REDIS_CLUSTER) {
-    const hosts = REDIS_URI.split(',').map((host) => {return { url: host }});
+  if (isEnabled(USE_REDIS_CLUSTER)) {
+    const hosts = REDIS_URI.split(',')
+      .map((host) => {
+        // TODO parse `host` input to handle connection strings
+        return { host: host };
+      });
     const cluster = new ioredis.Cluster(hosts, { redisOptions });
     keyvRedis = new KeyvRedis(cluster, keyvOpts);
   } else {

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -59,7 +59,7 @@ if (REDIS_URI && isEnabled(USE_REDIS)) {
 
       return {
         host: value.host,
-        port: value.port
+        port: value.port,
       };
     });
     const cluster = new ioredis.Cluster(hosts, { redisOptions });


### PR DESCRIPTION
This pull request includes changes to the `api/cache/keyvRedis.js` file to allow LibreChat to connect to a clustered Redis.

This will specifically allow Librechat to connect to Google Memorystore Redis Cluster using TLS.

## Config Changes

There are two new environment variables:

| Key | Type | Description | Example |
| -----------| --- | ----------- | ---------|
| USE_REDIS_CLUSTER | `boolean` | Instructs LibreChat to use the `Cluster` mode to connect to Redis | `true` |
| REDIS_CA | `string` | If set, instruct LibreChat to use TLS with server authentication, using the file set in this variable as a PEM-encoded certificate authority. | `/memorystore/ca` |

## How it was found

If you read the `@keyv/redis` code in `node_modules/@keyv/redis/dist/index.js` you find this:

![image](https://github.com/user-attachments/assets/3a905d44-4139-40b5-b281-10628fb3ed27)

The `ioredis_1` object they imported is used down below 

![image](https://github.com/user-attachments/assets/b7f45a60-3e88-4938-86d2-83f9efa46903)

and you notice that, in case the `uri` parameter is not a string and it has a `'family'` property or a `isCluster` true property, then you simply use that first parameter as the redis client, as seen by the line:

```javascript
            this.redis = uri;
```

Now we know we need to focus our attention in the `ioredis` library.

Checking their README in https://github.com/redis/ioredis/tree/main?tab=readme-ov-file we find no damn example on how to connect to a Cluster, except this entry:

![image](https://github.com/user-attachments/assets/d4e9f504-291b-43dd-9a51-24fb35bdcef0)

Reading that we find an object, with this constructor:

![image](https://github.com/user-attachments/assets/5435ebf9-2b1f-48ab-addf-89c76ad8d991)

So we know we need to give it an array of ClusterNode objects:
![image](https://github.com/user-attachments/assets/5cbc2a93-978a-4fb0-9b9c-62f39f540ade)
Those are just a string or, better yet, objects with the keys `host` and `port`.

We also can pass a ClusterOptions object, as defined in https://redis.github.io/ioredis/interfaces/ClusterOptions.html.

Now, the TLS part. If you read it carefully, nothing in the docs above talk about TLS. However, there's a clue in the README:

![image](https://github.com/user-attachments/assets/8834585e-73da-42e3-967f-e22e25e55f2a)

That TLS property comes from https://nodejs.org/api/tls.html so I guess it's something wider than this library properties.

True enough, if you go down the rabbit hole you find this: https://github.com/redis/ioredis/blob/ca5e9405f80318ef35c42d23da640df4b88b6670/lib/connectors/StandaloneConnector.ts#L42-L44
and now you know that, for every connector, anything you send as RedisOptions that has a TLS key will simply be set in the ConnectionOptions of the createTLSConnection method.

These two specific changes enable the library to correctly connect to our Memorystore cluster using TLS.

## How it was tested

Regex testing:
![image](https://github.com/user-attachments/assets/25dd2354-ee24-41cb-a925-ea06b8bb726f)

Started a node pod in the cluster via `kubectl run --rm -it node-18 --image node:18-bullseye` (should have used node-20 but that was what the developer-defined in `.devcontainer/Dockerfile` so I went with it.

Then attached to that running pod via vscode: https://code.visualstudio.com/docs/devcontainers/attach-container 

Checked out the code, defined my `.env` file (using the deployment env vars where required, like MongoDB or pointing to the RAG api) and used the very own vscode debug file to check my work.

I was able to validate that the object is correctly recognized as a Cluster after creation:
![image](https://github.com/user-attachments/assets/27af6fe1-ad42-4d40-b67f-5b19a47af7ff)

We see the TLS definition there:
![image](https://github.com/user-attachments/assets/3ee3a248-4d56-4983-acb4-b5354b6ec684)

After letting the program run for a while and breaking, for instance, in here:
![image](https://github.com/user-attachments/assets/228b65ad-f4dd-44b6-b2e4-fdb767c8ca2f)

I can now see that the Redis client is in the `read` status. 

![image](https://github.com/user-attachments/assets/bd8830c6-6d65-4493-abb7-c50d5660bfbe)

## TODOs that are required

Right now it expects that REDIS_URI contains a hostname, and if you send it a connection string, like `redis://10.158.146.69:6379`, it will break in the `reconnecting` state.

![image](https://github.com/user-attachments/assets/9b520e61-02e5-48e1-a82a-f0afe5657ae2)

The code is already prepared to process an array of hosts **but** I am not sure the comma is a great separator.

In case the REDIS_CA file is not there, this will fail with a generic fs exception. We should throw a specific one related to the CA file not being found despite the variable being set.