### PR TITLE
Added the option to change the default trusted proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ DOMAIN_CLIENT=http://localhost:3080
 DOMAIN_SERVER=http://localhost:3080
 
 NO_INDEX=true
+# Use the address that is at most n number of hops away from the Express application. 
+# req.socket.remoteAddress is the first hop, and the rest are looked for in the X-Forwarded-For header from right to left. 
+# A value of 0 means that the first untrusted address would be req.socket.remoteAddress, i.e. there is no reverse proxy.
+# Defaulted to 1.
+TRUST_PROXY=1
 
 #===============#
 # JSON Logging  #

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -22,10 +22,11 @@ const staticCache = require('./utils/staticCache');
 const noIndex = require('./middleware/noIndex');
 const routes = require('./routes');
 
-const { PORT, HOST, ALLOW_SOCIAL_LOGIN, DISABLE_COMPRESSION } = process.env ?? {};
+const { PORT, HOST, ALLOW_SOCIAL_LOGIN, DISABLE_COMPRESSION, TRUST_PROXY } = process.env ?? {};
 
 const port = Number(PORT) || 3080;
 const host = HOST || 'localhost';
+const trusted_proxy = Number(TRUST_PROXY) || 1; /* trust first proxy by default */
 
 const startServer = async () => {
   if (typeof Bun !== 'undefined') {
@@ -53,7 +54,7 @@ const startServer = async () => {
   app.use(staticCache(app.locals.paths.dist));
   app.use(staticCache(app.locals.paths.fonts));
   app.use(staticCache(app.locals.paths.assets));
-  app.set('trust proxy', 1); /* trust first proxy */
+  app.set('trust proxy', trusted_proxy);
   app.use(cors());
   app.use(cookieParser());
 


### PR DESCRIPTION
## Summary

This gives the ability to choose what proxy to use as trustworthy.
The changes are focused on the api/server/index.js file.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Config Changes

There are two new environment variables:

| Key | Type | Description | Example |
| -----------| --- | ----------- | ---------|
| TRUST_PROXY | `numeric` | Instructs LibreChat to use the proxy no. # as it's a trustworthy one. | `1` |

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented on any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules.